### PR TITLE
Create health insurance sorting page

### DIFF
--- a/lib/pages/cotizador_salud.dart
+++ b/lib/pages/cotizador_salud.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+class CotizadorSaludPage extends StatefulWidget {
+  const CotizadorSaludPage({super.key});
+
+  @override
+  State<CotizadorSaludPage> createState() => _CotizadorSaludPageState();
+}
+
+class _CotizadorSaludPageState extends State<CotizadorSaludPage> {
+  final List<String> _aspects = [
+    'Precio',
+    'Monto de cobertura',
+    'Red de hospitales donde atenderme',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Cotizador de Salud'),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Text(
+                'Ordena los aspectos m\u00e1s importantes al cotizar:',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+              ),
+              const SizedBox(height: 20),
+              Expanded(
+                child: ReorderableListView.builder(
+                  itemCount: _aspects.length,
+                  onReorder: (oldIndex, newIndex) {
+                    setState(() {
+                      if (newIndex > oldIndex) {
+                        newIndex -= 1;
+                      }
+                      final item = _aspects.removeAt(oldIndex);
+                      _aspects.insert(newIndex, item);
+                    });
+                  },
+                  itemBuilder: (context, index) {
+                    final aspect = _aspects[index];
+                    return Card(
+                      key: ValueKey(aspect),
+                      child: ListTile(
+                        leading: CircleAvatar(
+                          child: Text('${index + 1}'),
+                        ),
+                        title: Text(aspect),
+                        trailing: const Icon(Icons.drag_handle),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'cotizador_salud.dart';
 
 class LandingPage extends StatelessWidget {
   const LandingPage({super.key});
@@ -44,7 +45,12 @@ class LandingPage extends StatelessWidget {
                     title: 'Seguro de Salud',
                     imagePath: 'assets/images/health.png',
                     onPressed: () {
-                      // Navegar a cotización de salud
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const CotizadorSaludPage(),
+                        ),
+                      );
                     },
                   ),
                 ],


### PR DESCRIPTION
## Summary
- add `CotizadorSaludPage` for sorting health insurance priorities
- link health insurance card to the new page

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68648b649bd8832fa668d2bdb99cf3ec