### PR TITLE
Enable reorder from anywhere in card

### DIFF
--- a/lib/pages/cotizador_salud.dart
+++ b/lib/pages/cotizador_salud.dart
@@ -39,6 +39,7 @@ class _CotizadorSaludPageState extends State<CotizadorSaludPage> {
                   const SizedBox(height: 20),
                   Expanded(
                     child: ReorderableListView.builder(
+                      buildDefaultDragHandles: false,
                       itemCount: _aspects.length,
                       onReorder: (oldIndex, newIndex) {
                         setState(() {
@@ -51,14 +52,17 @@ class _CotizadorSaludPageState extends State<CotizadorSaludPage> {
                       },
                       itemBuilder: (context, index) {
                         final aspect = _aspects[index];
-                        return Card(
+                        return ReorderableDelayedDragStartListener(
                           key: ValueKey(aspect),
-                          child: ListTile(
-                            leading: CircleAvatar(
-                              child: Text('${index + 1}'),
+                          index: index,
+                          child: Card(
+                            child: ListTile(
+                              leading: CircleAvatar(
+                                child: Text('${index + 1}'),
+                              ),
+                              title: Text(aspect),
+                              trailing: const Icon(Icons.drag_handle),
                             ),
-                            title: Text(aspect),
-                            trailing: const Icon(Icons.drag_handle),
                           ),
                         );
                       },


### PR DESCRIPTION
## Summary
- allow dragging entire card in cotizador_salud

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686496a9104c832fad0ccc5f26301b40