### PR TITLE
Agregar consulta de placa para cotizador auto

### DIFF
--- a/lib/models/vehicle_info.dart
+++ b/lib/models/vehicle_info.dart
@@ -1,0 +1,125 @@
+class VehicleInfo {
+  final Vehiculo? vehiculo;
+  final dynamic rubros;
+
+  VehicleInfo({this.vehiculo, this.rubros});
+
+  factory VehicleInfo.fromJson(Map<String, dynamic> json) {
+    return VehicleInfo(
+      vehiculo:
+          json['vehiculo'] != null ? Vehiculo.fromJson(json['vehiculo']) : null,
+      rubros: json['rubros'],
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'vehiculo': vehiculo?.toJson(),
+        'rubros': rubros,
+      };
+}
+
+class Vehiculo {
+  final int? codigoVehiculo;
+  final String? numeroPlaca;
+  final String? numeroCamvCpn;
+  final String? colorVehiculo1;
+  final String? colorVehiculo2;
+  final dynamic cilindraje;
+  final String? nombreClase;
+  final String? descripcionMarca;
+  final String? descripcionModelo;
+  final int? anioAuto;
+  final String? descripcionPais;
+  final String? mensajeMotivoAuto;
+  final bool? aplicaCuota;
+  final String? fechaUltimaMatricula;
+  final String? fechaCaducidadMatricula;
+  final String? fechaCompraRegistro;
+  final String? fechaRevision;
+  final String? descripcionCanton;
+  final String? descripcionServicio;
+  final int? ultimoAnioPagado;
+  final String? prohibidoEnajenar;
+  final String? observacion;
+  final String? estadoExoneracion;
+
+  Vehiculo({
+    this.codigoVehiculo,
+    this.numeroPlaca,
+    this.numeroCamvCpn,
+    this.colorVehiculo1,
+    this.colorVehiculo2,
+    this.cilindraje,
+    this.nombreClase,
+    this.descripcionMarca,
+    this.descripcionModelo,
+    this.anioAuto,
+    this.descripcionPais,
+    this.mensajeMotivoAuto,
+    this.aplicaCuota,
+    this.fechaUltimaMatricula,
+    this.fechaCaducidadMatricula,
+    this.fechaCompraRegistro,
+    this.fechaRevision,
+    this.descripcionCanton,
+    this.descripcionServicio,
+    this.ultimoAnioPagado,
+    this.prohibidoEnajenar,
+    this.observacion,
+    this.estadoExoneracion,
+  });
+
+  factory Vehiculo.fromJson(Map<String, dynamic> json) {
+    return Vehiculo(
+      codigoVehiculo: json['codigoVehiculo'] as int?,
+      numeroPlaca: json['numeroPlaca'] as String?,
+      numeroCamvCpn: json['numeroCamvCpn'] as String?,
+      colorVehiculo1: json['colorVehiculo1'] as String?,
+      colorVehiculo2: json['colorVehiculo2'] as String?,
+      cilindraje: json['cilindraje'],
+      nombreClase: json['nombreClase'] as String?,
+      descripcionMarca: json['descripcionMarca'] as String?,
+      descripcionModelo: json['descripcionModelo'] as String?,
+      anioAuto: json['anioAuto'] as int?,
+      descripcionPais: json['descripcionPais'] as String?,
+      mensajeMotivoAuto: json['mensajeMotivoAuto'] as String?,
+      aplicaCuota: json['aplicaCuota'] as bool?,
+      fechaUltimaMatricula: json['fechaUltimaMatricula'] as String?,
+      fechaCaducidadMatricula: json['fechaCaducidadMatricula'] as String?,
+      fechaCompraRegistro: json['fechaCompraRegistro'] as String?,
+      fechaRevision: json['fechaRevision'] as String?,
+      descripcionCanton: json['descripcionCanton'] as String?,
+      descripcionServicio: json['descripcionServicio'] as String?,
+      ultimoAnioPagado: json['ultimoAnioPagado'] as int?,
+      prohibidoEnajenar: json['prohibidoEnajenar'] as String?,
+      observacion: json['observacion'] as String?,
+      estadoExoneracion: json['estadoExoneracion'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'codigoVehiculo': codigoVehiculo,
+        'numeroPlaca': numeroPlaca,
+        'numeroCamvCpn': numeroCamvCpn,
+        'colorVehiculo1': colorVehiculo1,
+        'colorVehiculo2': colorVehiculo2,
+        'cilindraje': cilindraje,
+        'nombreClase': nombreClase,
+        'descripcionMarca': descripcionMarca,
+        'descripcionModelo': descripcionModelo,
+        'anioAuto': anioAuto,
+        'descripcionPais': descripcionPais,
+        'mensajeMotivoAuto': mensajeMotivoAuto,
+        'aplicaCuota': aplicaCuota,
+        'fechaUltimaMatricula': fechaUltimaMatricula,
+        'fechaCaducidadMatricula': fechaCaducidadMatricula,
+        'fechaCompraRegistro': fechaCompraRegistro,
+        'fechaRevision': fechaRevision,
+        'descripcionCanton': descripcionCanton,
+        'descripcionServicio': descripcionServicio,
+        'ultimoAnioPagado': ultimoAnioPagado,
+        'prohibidoEnajenar': prohibidoEnajenar,
+        'observacion': observacion,
+        'estadoExoneracion': estadoExoneracion,
+      };
+}

--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'cotizador_salud.dart';
+import 'preferencias_cotizador_auto.dart';
 import '../widgets/whatsapp_button.dart';
 
 class LandingPage extends StatelessWidget {
@@ -40,7 +41,12 @@ class LandingPage extends StatelessWidget {
                     title: 'Seguro de Auto',
                     imagePath: 'assets/images/car.png',
                     onPressed: () {
-                      // Navegar a cotización de auto
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const PreferenciasCotizadorAutoPage(),
+                        ),
+                      );
                     },
                   ),
                   _InsuranceCard(

--- a/lib/pages/preferencias_cotizador_auto.dart
+++ b/lib/pages/preferencias_cotizador_auto.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+import '../services/vehicle_info_service.dart';
+import '../widgets/whatsapp_button.dart';
+
+class PreferenciasCotizadorAutoPage extends StatefulWidget {
+  const PreferenciasCotizadorAutoPage({super.key});
+
+  @override
+  State<PreferenciasCotizadorAutoPage> createState() =>
+      _PreferenciasCotizadorAutoPageState();
+}
+
+class _PreferenciasCotizadorAutoPageState
+    extends State<PreferenciasCotizadorAutoPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _plateController = TextEditingController();
+  final _service = VehicleInfoService();
+
+  String? _result;
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    _plateController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _consultar() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() {
+      _loading = true;
+      _result = null;
+    });
+    try {
+      final response = await _service.fetchVehicleInfo(_plateController.text);
+      setState(() {
+        _result = response;
+      });
+    } catch (e) {
+      setState(() {
+        _result = 'Error al consultar: $e';
+      });
+    } finally {
+      setState(() {
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Cotizador Auto'),
+      ),
+      floatingActionButton: const WhatsappButton(),
+      body: SafeArea(
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 600),
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    TextFormField(
+                      controller: _plateController,
+                      decoration: const InputDecoration(
+                        labelText: 'Placa del vehículo',
+                      ),
+                      validator: (value) =>
+                          value == null || value.isEmpty ? 'Campo obligatorio' : null,
+                    ),
+                    const SizedBox(height: 16),
+                    ElevatedButton(
+                      onPressed: _loading ? null : _consultar,
+                      child: _loading
+                          ? const SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Text('Consultar'),
+                    ),
+                    const SizedBox(height: 16),
+                    if (_result != null)
+                      Expanded(
+                        child: SingleChildScrollView(
+                          child: Text(_result!),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/preferencias_cotizador_auto.dart
+++ b/lib/pages/preferencias_cotizador_auto.dart
@@ -1,5 +1,8 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
+import '../models/vehicle_info.dart';
 import '../services/vehicle_info_service.dart';
 import '../widgets/whatsapp_button.dart';
 
@@ -17,7 +20,7 @@ class _PreferenciasCotizadorAutoPageState
   final _plateController = TextEditingController();
   final _service = VehicleInfoService();
 
-  String? _result;
+  VehicleInfo? _info;
   bool _loading = false;
 
   @override
@@ -31,16 +34,16 @@ class _PreferenciasCotizadorAutoPageState
 
     setState(() {
       _loading = true;
-      _result = null;
+      _info = null;
     });
     try {
       final response = await _service.fetchVehicleInfo(_plateController.text);
       setState(() {
-        _result = response;
+        _info = response;
       });
     } catch (e) {
       setState(() {
-        _result = 'Error al consultar: $e';
+        _info = null;
       });
     } finally {
       setState(() {
@@ -88,10 +91,12 @@ class _PreferenciasCotizadorAutoPageState
                           : const Text('Consultar'),
                     ),
                     const SizedBox(height: 16),
-                    if (_result != null)
+                    if (_info != null)
                       Expanded(
                         child: SingleChildScrollView(
-                          child: Text(_result!),
+                          child: Text(
+                            JsonEncoder.withIndent('  ').convert(_info!.toJson()),
+                          ),
                         ),
                       ),
                   ],

--- a/lib/services/vehicle_info_service.dart
+++ b/lib/services/vehicle_info_service.dart
@@ -1,0 +1,14 @@
+import 'package:http/http.dart' as http;
+
+class VehicleInfoService {
+  Future<String> fetchVehicleInfo(String plate) async {
+    final url = Uri.parse(
+        'https://www.ecuadorlegalonline.com/modulo/sri/matriculacion/consultar-vehiculo-rubros.php?placa=$plate');
+    final response = await http.get(url);
+    if (response.statusCode == 200) {
+      return response.body;
+    } else {
+      throw Exception('Error al obtener información del vehículo');
+    }
+  }
+}

--- a/lib/services/vehicle_info_service.dart
+++ b/lib/services/vehicle_info_service.dart
@@ -1,4 +1,8 @@
+import 'dart:convert';
+
 import 'package:http/http.dart' as http;
+
+import '../models/vehicle_info.dart';
 
 class VehicleInfoService {
   /// Obtiene información del vehículo consultando la web de Ecuador Legal.
@@ -6,7 +10,7 @@ class VehicleInfoService {
   /// Se agregan algunas cabeceras para replicar la petición que realiza el
   /// aplicativo web original, ya que sin ellas el servidor puede responder de
   /// forma inesperada.
-  Future<String> fetchVehicleInfo(String plate) async {
+  Future<VehicleInfo> fetchVehicleInfo(String plate) async {
     final url = Uri.parse(
       'https://www.ecuadorlegalonline.com/modulo/sri/matriculacion/consultar-vehiculo-rubros.php?placa=$plate',
     );
@@ -23,9 +27,9 @@ class VehicleInfoService {
     });
 
     if (response.statusCode == 200) {
-      return response.body;
-    } else {
-      throw Exception('Error al obtener información del vehículo');
+      final Map<String, dynamic> data = json.decode(response.body);
+      return VehicleInfo.fromJson(data);
     }
+    throw Exception('Error al obtener información del vehículo');
   }
 }

--- a/lib/services/vehicle_info_service.dart
+++ b/lib/services/vehicle_info_service.dart
@@ -1,10 +1,27 @@
 import 'package:http/http.dart' as http;
 
 class VehicleInfoService {
+  /// Obtiene información del vehículo consultando la web de Ecuador Legal.
+  ///
+  /// Se agregan algunas cabeceras para replicar la petición que realiza el
+  /// aplicativo web original, ya que sin ellas el servidor puede responder de
+  /// forma inesperada.
   Future<String> fetchVehicleInfo(String plate) async {
     final url = Uri.parse(
-        'https://www.ecuadorlegalonline.com/modulo/sri/matriculacion/consultar-vehiculo-rubros.php?placa=$plate');
-    final response = await http.get(url);
+      'https://www.ecuadorlegalonline.com/modulo/sri/matriculacion/consultar-vehiculo-rubros.php?placa=$plate',
+    );
+
+    final response = await http.get(url, headers: {
+      'Accept': '*/*',
+      'Accept-Language': 'es-ES,es;q=0.9,en;q=0.8',
+      'Accept-Encoding': 'gzip, deflate, br, zstd',
+      'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36',
+      'X-Requested-With': 'XMLHttpRequest',
+      'Referer':
+          'https://www.ecuadorlegalonline.com/consultas/agencia-nacional-de-transito/consultar-a-quien-pertenece-un-vehiculo-por-placa-ant/',
+    });
+
     if (response.statusCode == 200) {
       return response.body;
     } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  http: ^0.13.6
   url_launcher: ^6.1.6
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add HTTP dependency for network calls
- create `VehicleInfoService` to fetch vehicle information
- implement `PreferenciasCotizadorAutoPage` to input vehicle plate and show API response
- link auto card on landing page to the new page

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686532cf61b8832faa74a3ad07aa7190