### PR TITLE
Update auto quote page with summary and navigation

### DIFF
--- a/lib/pages/cotizador_auto.dart
+++ b/lib/pages/cotizador_auto.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import '../widgets/whatsapp_button.dart';
+
+class CotizadorAutoPage extends StatelessWidget {
+  const CotizadorAutoPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Cotizador Auto'),
+      ),
+      floatingActionButton: const WhatsappButton(),
+      body: const SafeArea(
+        child: Center(
+          child: Text('Pantalla de cotizador de auto'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/preferencias_cotizador_auto.dart
+++ b/lib/pages/preferencias_cotizador_auto.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import '../models/vehicle_info.dart';
 import '../services/vehicle_info_service.dart';
 import '../widgets/whatsapp_button.dart';
+import 'cotizador_auto.dart';
 
 class PreferenciasCotizadorAutoPage extends StatefulWidget {
   const PreferenciasCotizadorAutoPage({super.key});
@@ -18,6 +19,7 @@ class _PreferenciasCotizadorAutoPageState
     extends State<PreferenciasCotizadorAutoPage> {
   final _formKey = GlobalKey<FormState>();
   final _plateController = TextEditingController(text: 'PFH1781');
+  final _valorComercialController = TextEditingController(text: '15000');
   final _service = VehicleInfoService();
 
   VehicleInfo? _info;
@@ -26,6 +28,7 @@ class _PreferenciasCotizadorAutoPageState
   @override
   void dispose() {
     _plateController.dispose();
+    _valorComercialController.dispose();
     super.dispose();
   }
 
@@ -81,7 +84,8 @@ class _PreferenciasCotizadorAutoPageState
                     ),
                     const SizedBox(height: 16),
                     ElevatedButton(
-                      onPressed: _loading ? null : _consultar,
+                      onPressed:
+                          _loading || _info != null ? null : _consultar,
                       child: _loading
                           ? const SizedBox(
                               width: 20,
@@ -91,14 +95,46 @@ class _PreferenciasCotizadorAutoPageState
                           : const Text('Consultar'),
                     ),
                     const SizedBox(height: 16),
-                    if (_info != null)
+                    if (_info != null) ...[
                       Expanded(
                         child: SingleChildScrollView(
-                          child: Text(
-                            JsonEncoder.withIndent('  ').convert(_info!.toJson()),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'El vehículo de marca ${_info!.vehiculo?.descripcionMarca ?? ''}, modelo: ${_info!.vehiculo?.descripcionModelo ?? ''} del año ${_info!.vehiculo?.anioAuto ?? ''}',
+                              ),
+                              const SizedBox(height: 16),
+                              Text(
+                                'Valor comercial sugerido a la fecha ${_valorComercialController.text} dólares',
+                              ),
+                              const SizedBox(height: 8),
+                              TextFormField(
+                                controller: _valorComercialController,
+                                decoration: const InputDecoration(
+                                  labelText: 'Modificar valor comercial',
+                                  suffixText: 'dólares',
+                                ),
+                                keyboardType: TextInputType.number,
+                                onChanged: (_) => setState(() {}),
+                              ),
+                            ],
                           ),
                         ),
                       ),
+                      const SizedBox(height: 16),
+                      ElevatedButton(
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => const CotizadorAutoPage(),
+                            ),
+                          );
+                        },
+                        child: const Text('Cotizar'),
+                      ),
+                    ],
                   ],
                 ),
               ),


### PR DESCRIPTION
## Summary
- add CotizadorAutoPage screen
- show vehicle summary with editable commercial value
- disable Consultar button after info is loaded and add Cotizar button

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865d1ddeb34832f82040afd3b75fa82