### PR TITLE
Enable drag on entire tile for health quote list

### DIFF
--- a/lib/pages/cotizador_salud.dart
+++ b/lib/pages/cotizador_salud.dart
@@ -41,6 +41,7 @@ class _CotizadorSaludPageState extends State<CotizadorSaludPage> {
                   const SizedBox(height: 20),
                   Expanded(
                     child: ReorderableListView.builder(
+                      buildDefaultDragHandles: false,
                       itemCount: _aspects.length,
                       onReorder: (oldIndex, newIndex) {
                         setState(() {
@@ -53,14 +54,16 @@ class _CotizadorSaludPageState extends State<CotizadorSaludPage> {
                       },
                       itemBuilder: (context, index) {
                         final aspect = _aspects[index];
-                        return Card(
+                        return ReorderableDragStartListener(
                           key: ValueKey(aspect),
-                          child: ListTile(
-                            leading: CircleAvatar(
-                              child: Text('${index + 1}'),
+                          index: index,
+                          child: Card(
+                            child: ListTile(
+                              leading: CircleAvatar(
+                                child: Text('${index + 1}'),
+                              ),
+                              title: Text(aspect),
                             ),
-                            title: Text(aspect),
-                            //trailing: const Icon(Icons.drag_handle),
                           ),
                         );
                       },


### PR DESCRIPTION
## Summary
- allow dragging an aspect from any part of the card in cotizador_salud

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869143ca248832f9b3b970632a6f40a