### PR TITLE
Fetch health preferences from API

### DIFF
--- a/lib/models/preference_option.dart
+++ b/lib/models/preference_option.dart
@@ -1,0 +1,18 @@
+class PreferenceOption {
+  final String id;
+  final String descripcion;
+
+  PreferenceOption({required this.id, required this.descripcion});
+
+  factory PreferenceOption.fromJson(Map<String, dynamic> json) {
+    return PreferenceOption(
+      id: json['id'].toString(),
+      descripcion: json['descripcion'] as String? ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'descripcion': descripcion,
+      };
+}

--- a/lib/pages/cotizador_salud.dart
+++ b/lib/pages/cotizador_salud.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'formulario_cotizador_salud.dart';
 import '../widgets/whatsapp_button.dart';
+import '../services/preferencias_salud_service.dart';
+import '../models/preference_option.dart';
 
 class CotizadorSaludPage extends StatefulWidget {
   const CotizadorSaludPage({super.key});
@@ -11,83 +13,114 @@ class CotizadorSaludPage extends StatefulWidget {
 }
 
 class _CotizadorSaludPageState extends State<CotizadorSaludPage> {
-  final List<String> _aspects = [
-    'Monto de cobertura - Suma asegurada',
-    'Red de hospitales donde atenderme',
-    'Precio que pagaré por el servicio',
-  ];
+  final _service = PreferenciasSaludService();
+  List<String> _aspects = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadOptions();
+  }
+
+  Future<void> _loadOptions() async {
+    try {
+      final options = await _service.fetchOptions();
+      setState(() {
+        _aspects = options.map((e) => e.descripcion).toList();
+      });
+    } catch (_) {
+      setState(() {
+        _aspects = [];
+      });
+    } finally {
+      setState(() {
+        _loading = false;
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        floatingActionButton: const WhatsappButton(),
-        appBar: AppBar(
-          title: const Text('Cotizador de Salud'),
-        ),
-        body: SafeArea(
-            child: Align(
+      floatingActionButton: const WhatsappButton(),
+      appBar: AppBar(
+        title: const Text('Cotizador de Salud'),
+      ),
+      body: SafeArea(
+        child: Align(
           alignment: Alignment.topCenter,
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 600),
             child: Padding(
               padding: const EdgeInsets.all(16.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  const Text(
-                    'Ordena los aspectos más importantes para ti al momento de seleccionar un seguro:',
-                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
-                  ),
-                  const SizedBox(height: 20),
-                  Expanded(
-                    child: ReorderableListView.builder(
-                      buildDefaultDragHandles: false,
-                      itemCount: _aspects.length,
-                      onReorder: (oldIndex, newIndex) {
-                        setState(() {
-                          if (newIndex > oldIndex) {
-                            newIndex -= 1;
-                          }
-                          final item = _aspects.removeAt(oldIndex);
-                          _aspects.insert(newIndex, item);
-                        });
-                      },
-                      itemBuilder: (context, index) {
-                        final aspect = _aspects[index];
-                        return ReorderableDragStartListener(
-                          key: ValueKey(aspect),
-                          index: index,
-                          child: Card(
-                            child: ListTile(
-                              leading: CircleAvatar(
-                                child: Text('${index + 1}'),
-                              ),
-                              title: Text(aspect),
-                              trailing: const Icon(Icons.open_with_outlined),
-                            ),
-                          ),
-                        );
-                      },
-                    ),
-                  ),
-                  const SizedBox(height: 20),
-                  ElevatedButton(
-                    onPressed: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => FormularioCotizadorSaludPage(
-                            orderedAspects: List<String>.from(_aspects),
+              child: _loading
+                  ? const Center(child: CircularProgressIndicator())
+                  : Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        const Text(
+                          'Ordena los aspectos más importantes para ti al momento de seleccionar un seguro:',
+                          style: TextStyle(
+                              fontSize: 16, fontWeight: FontWeight.w600),
+                        ),
+                        const SizedBox(height: 20),
+                        Expanded(
+                          child: ReorderableListView.builder(
+                            buildDefaultDragHandles: false,
+                            itemCount: _aspects.length,
+                            onReorder: (oldIndex, newIndex) {
+                              setState(() {
+                                if (newIndex > oldIndex) {
+                                  newIndex -= 1;
+                                }
+                                final item = _aspects.removeAt(oldIndex);
+                                _aspects.insert(newIndex, item);
+                              });
+                            },
+                            itemBuilder: (context, index) {
+                              final aspect = _aspects[index];
+                              return ReorderableDragStartListener(
+                                key: ValueKey(aspect),
+                                index: index,
+                                child: Card(
+                                  child: ListTile(
+                                    leading: CircleAvatar(
+                                      child: Text('${index + 1}'),
+                                    ),
+                                    title: Text(aspect),
+                                    trailing:
+                                        const Icon(Icons.open_with_outlined),
+                                  ),
+                                ),
+                              );
+                            },
                           ),
                         ),
-                      );
-                    },
-                    child: const Text('Cotizar'),
-                  ),
-                ],
-              ),
+                        const SizedBox(height: 20),
+                        ElevatedButton(
+                          onPressed: _aspects.isEmpty
+                              ? null
+                              : () {
+                                  Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (_) =>
+                                          FormularioCotizadorSaludPage(
+                                        orderedAspects:
+                                            List<String>.from(_aspects),
+                                      ),
+                                    ),
+                                  );
+                                },
+                          child: const Text('Cotizar'),
+                        ),
+                      ],
+                    ),
             ),
           ),
-        )));
+        ),
+      ),
+    );
   }
 }

--- a/lib/services/preferencias_salud_service.dart
+++ b/lib/services/preferencias_salud_service.dart
@@ -1,0 +1,33 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+import 'auth_service.dart';
+import '../models/preference_option.dart';
+
+class PreferenciasSaludService {
+  Future<List<PreferenceOption>> fetchOptions() async {
+    final baseUrl = dotenv.env['API_BASE_URL'] ?? 'http://127.0.0.1:8000';
+    final url = Uri.parse('$baseUrl/api/opciones_preferencias_salud');
+    final token = await AuthService().getToken();
+    final headers = token != null
+        ? {
+            'Authorization': 'Bearer $token',
+            'Accept': 'application/json',
+          }
+        : {
+            'Accept': 'application/json',
+          };
+
+    final response = await http.get(url, headers: headers);
+
+    if (response.statusCode == 200) {
+      final List<dynamic> data = json.decode(response.body);
+      return data
+          .map((e) => PreferenceOption.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    throw Exception('Error al obtener opciones de preferencias de salud');
+  }
+}


### PR DESCRIPTION
## Summary
- add PreferenceOption model
- add PreferenciasSaludService for API calls
- load health preferences via API in `cotizador_salud.dart`

## Testing
- `flutter format lib/models/preference_option.dart lib/services/preferencias_salud_service.dart lib/pages/cotizador_salud.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c85875b44832f8b86f697d8a172d0