### PR TITLE
Update vehicle info service for new API response

### DIFF
--- a/lib/models/vehicle_info.dart
+++ b/lib/models/vehicle_info.dart
@@ -1,125 +1,88 @@
 class VehicleInfo {
   final Vehiculo? vehiculo;
-  final dynamic rubros;
 
-  VehicleInfo({this.vehiculo, this.rubros});
+  VehicleInfo({this.vehiculo});
 
   factory VehicleInfo.fromJson(Map<String, dynamic> json) {
     return VehicleInfo(
       vehiculo:
           json['vehiculo'] != null ? Vehiculo.fromJson(json['vehiculo']) : null,
-      rubros: json['rubros'],
     );
   }
 
   Map<String, dynamic> toJson() => {
         'vehiculo': vehiculo?.toJson(),
-        'rubros': rubros,
       };
 }
 
 class Vehiculo {
   final int? codigoVehiculo;
   final String? numeroPlaca;
-  final String? numeroCamvCpn;
-  final String? colorVehiculo1;
-  final String? colorVehiculo2;
-  final dynamic cilindraje;
-  final String? nombreClase;
   final String? descripcionMarca;
   final String? descripcionModelo;
   final int? anioAuto;
   final String? descripcionPais;
-  final String? mensajeMotivoAuto;
-  final bool? aplicaCuota;
-  final String? fechaUltimaMatricula;
-  final String? fechaCaducidadMatricula;
-  final String? fechaCompraRegistro;
-  final String? fechaRevision;
-  final String? descripcionCanton;
-  final String? descripcionServicio;
-  final int? ultimoAnioPagado;
-  final String? prohibidoEnajenar;
-  final String? observacion;
-  final String? estadoExoneracion;
+  final List<OpcionComercial>? opcionesComerciales;
 
   Vehiculo({
     this.codigoVehiculo,
     this.numeroPlaca,
-    this.numeroCamvCpn,
-    this.colorVehiculo1,
-    this.colorVehiculo2,
-    this.cilindraje,
-    this.nombreClase,
     this.descripcionMarca,
     this.descripcionModelo,
     this.anioAuto,
     this.descripcionPais,
-    this.mensajeMotivoAuto,
-    this.aplicaCuota,
-    this.fechaUltimaMatricula,
-    this.fechaCaducidadMatricula,
-    this.fechaCompraRegistro,
-    this.fechaRevision,
-    this.descripcionCanton,
-    this.descripcionServicio,
-    this.ultimoAnioPagado,
-    this.prohibidoEnajenar,
-    this.observacion,
-    this.estadoExoneracion,
+    this.opcionesComerciales,
   });
 
   factory Vehiculo.fromJson(Map<String, dynamic> json) {
     return Vehiculo(
       codigoVehiculo: json['codigoVehiculo'] as int?,
       numeroPlaca: json['numeroPlaca'] as String?,
-      numeroCamvCpn: json['numeroCamvCpn'] as String?,
-      colorVehiculo1: json['colorVehiculo1'] as String?,
-      colorVehiculo2: json['colorVehiculo2'] as String?,
-      cilindraje: json['cilindraje'],
-      nombreClase: json['nombreClase'] as String?,
       descripcionMarca: json['descripcionMarca'] as String?,
       descripcionModelo: json['descripcionModelo'] as String?,
       anioAuto: json['anioAuto'] as int?,
       descripcionPais: json['descripcionPais'] as String?,
-      mensajeMotivoAuto: json['mensajeMotivoAuto'] as String?,
-      aplicaCuota: json['aplicaCuota'] as bool?,
-      fechaUltimaMatricula: json['fechaUltimaMatricula'] as String?,
-      fechaCaducidadMatricula: json['fechaCaducidadMatricula'] as String?,
-      fechaCompraRegistro: json['fechaCompraRegistro'] as String?,
-      fechaRevision: json['fechaRevision'] as String?,
-      descripcionCanton: json['descripcionCanton'] as String?,
-      descripcionServicio: json['descripcionServicio'] as String?,
-      ultimoAnioPagado: json['ultimoAnioPagado'] as int?,
-      prohibidoEnajenar: json['prohibidoEnajenar'] as String?,
-      observacion: json['observacion'] as String?,
-      estadoExoneracion: json['estadoExoneracion'] as String?,
+      opcionesComerciales: json['opcionesComerciales'] != null
+          ? (json['opcionesComerciales'] as List)
+              .map((e) => OpcionComercial.fromJson(e))
+              .toList()
+          : null,
     );
   }
 
   Map<String, dynamic> toJson() => {
         'codigoVehiculo': codigoVehiculo,
         'numeroPlaca': numeroPlaca,
-        'numeroCamvCpn': numeroCamvCpn,
-        'colorVehiculo1': colorVehiculo1,
-        'colorVehiculo2': colorVehiculo2,
-        'cilindraje': cilindraje,
-        'nombreClase': nombreClase,
         'descripcionMarca': descripcionMarca,
         'descripcionModelo': descripcionModelo,
         'anioAuto': anioAuto,
         'descripcionPais': descripcionPais,
-        'mensajeMotivoAuto': mensajeMotivoAuto,
-        'aplicaCuota': aplicaCuota,
-        'fechaUltimaMatricula': fechaUltimaMatricula,
-        'fechaCaducidadMatricula': fechaCaducidadMatricula,
-        'fechaCompraRegistro': fechaCompraRegistro,
-        'fechaRevision': fechaRevision,
-        'descripcionCanton': descripcionCanton,
-        'descripcionServicio': descripcionServicio,
-        'ultimoAnioPagado': ultimoAnioPagado,
-        'prohibidoEnajenar': prohibidoEnajenar,
-        'observacion': observacion,
-        'estadoExoneracion': estadoExoneracion,
+        'opcionesComerciales':
+            opcionesComerciales?.map((e) => e.toJson()).toList(),
+      };
+}
+
+class OpcionComercial {
+  final String? marca;
+  final String? modelo;
+  final String? anio;
+  final String? precioComercial;
+
+  OpcionComercial({this.marca, this.modelo, this.anio, this.precioComercial});
+
+  factory OpcionComercial.fromJson(Map<String, dynamic> json) {
+    return OpcionComercial(
+      marca: json['marca'] as String?,
+      modelo: json['modelo'] as String?,
+      anio: json['anio'] as String?,
+      precioComercial: json['precioComercial'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'marca': marca,
+        'modelo': modelo,
+        'anio': anio,
+        'precioComercial': precioComercial,
       };
 }

--- a/lib/pages/preferencias_cotizador_auto.dart
+++ b/lib/pages/preferencias_cotizador_auto.dart
@@ -19,10 +19,11 @@ class _PreferenciasCotizadorAutoPageState
     extends State<PreferenciasCotizadorAutoPage> {
   final _formKey = GlobalKey<FormState>();
   final _plateController = TextEditingController(text: 'PFH1781');
-  final _valorComercialController = TextEditingController(text: '15000');
+  final _valorComercialController = TextEditingController(text: '0');
   final _service = VehicleInfoService();
 
   VehicleInfo? _info;
+  OpcionComercial? _selectedOpcion;
   bool _loading = false;
 
   @override
@@ -43,6 +44,12 @@ class _PreferenciasCotizadorAutoPageState
       final response = await _service.fetchVehicleInfo(_plateController.text);
       setState(() {
         _info = response;
+        final opciones = _info?.vehiculo?.opcionesComerciales;
+        if (opciones != null && opciones.isNotEmpty) {
+          _selectedOpcion = opciones.first;
+          _valorComercialController.text =
+              opciones.first.precioComercial?.trim() ?? '';
+        }
       });
     } catch (e) {
       setState(() {
@@ -102,10 +109,32 @@ class _PreferenciasCotizadorAutoPageState
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Text(
-                             'El vehículo de marca ${_info!.vehiculo?.descripcionMarca ?? ''}, modelo: ${_info!.vehiculo?.descripcionModelo ?? ''} del año ${_info!.vehiculo?.anioAuto ?? ''}',
-
+                                'El vehículo de marca ${_info!.vehiculo?.descripcionMarca ?? ''}, modelo: ${_info!.vehiculo?.descripcionModelo ?? ''} del año ${_info!.vehiculo?.anioAuto ?? ''}',
                               ),
                               const SizedBox(height: 16),
+                              if ((_info!.vehiculo?.opcionesComerciales?.length ?? 0) > 1)
+                                DropdownButtonFormField<OpcionComercial>(
+                                  value: _selectedOpcion,
+                                  decoration: const InputDecoration(labelText: 'Modelo'),
+                                  items: _info!.vehiculo!.opcionesComerciales!
+                                      .map(
+                                        (e) => DropdownMenuItem(
+                                          value: e,
+                                          child: Text('${e.modelo} - ${e.precioComercial}'),
+                                        ),
+                                      )
+                                      .toList(),
+                                  onChanged: (value) {
+                                    setState(() {
+                                      _selectedOpcion = value;
+                                      if (value != null) {
+                                        _valorComercialController.text = value.precioComercial?.trim() ?? '';
+                                      }
+                                    });
+                                  },
+                                ),
+                              if ((_info!.vehiculo?.opcionesComerciales?.length ?? 0) > 1)
+                                const SizedBox(height: 16),
                               Text(
                                 'Valor comercial sugerido a la fecha ${_valorComercialController.text} dólares',
                               ),

--- a/lib/services/vehicle_info_service.dart
+++ b/lib/services/vehicle_info_service.dart
@@ -10,7 +10,7 @@ class VehicleInfoService {
   /// Obtiene información del vehículo consultando el backend configurado.
   Future<VehicleInfo> fetchVehicleInfo(String plate) async {
     final baseUrl = dotenv.env['API_BASE_URL'] ?? 'http://127.0.0.1:8000';
-    final url = Uri.parse('$baseUrl/api/vehicle-info/$plate');
+    final url = Uri.parse('$baseUrl/api/info_placa/$plate');
     final token = await AuthService().getToken();
     final headers = token != null
         ? <String, String>{


### PR DESCRIPTION
## Summary
- adapt `VehicleInfoService` to new `/api/info_placa/<placa>` endpoint
- simplify `VehicleInfo` and `Vehiculo` models and add `OpcionComercial`
- set commercial value from first option and allow selecting other models

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c932cb42c832f9459394bee7c95dd