### PR TITLE
Add health quote API integration

### DIFF
--- a/lib/models/salud_quote.dart
+++ b/lib/models/salud_quote.dart
@@ -1,0 +1,31 @@
+class SaludQuote {
+  final String idProducto;
+  final String orden;
+  final String nombreProducto;
+  final String nombreAseguradora;
+  final String valor;
+  final String urlImagenAseguradora;
+  final String puntuacion;
+
+  SaludQuote({
+    required this.idProducto,
+    required this.orden,
+    required this.nombreProducto,
+    required this.nombreAseguradora,
+    required this.valor,
+    required this.urlImagenAseguradora,
+    required this.puntuacion,
+  });
+
+  factory SaludQuote.fromJson(Map<String, dynamic> json) {
+    return SaludQuote(
+      idProducto: json['idProducto'].toString(),
+      orden: json['orden'].toString(),
+      nombreProducto: json['nombrePorducto'] as String? ?? '',
+      nombreAseguradora: json['nombreAseguradora'] as String? ?? '',
+      valor: json['valor'].toString(),
+      urlImagenAseguradora: json['urlImagenAseguradora'] as String? ?? '',
+      puntuacion: json['puntuacion'].toString(),
+    );
+  }
+}

--- a/lib/pages/cotizador_salud.dart
+++ b/lib/pages/cotizador_salud.dart
@@ -14,7 +14,7 @@ class CotizadorSaludPage extends StatefulWidget {
 
 class _CotizadorSaludPageState extends State<CotizadorSaludPage> {
   final _service = PreferenciasSaludService();
-  List<String> _aspects = [];
+  List<PreferenceOption> _options = [];
   bool _loading = true;
 
   @override
@@ -27,11 +27,11 @@ class _CotizadorSaludPageState extends State<CotizadorSaludPage> {
     try {
       final options = await _service.fetchOptions();
       setState(() {
-        _aspects = options.map((e) => e.descripcion).toList();
+        _options = options;
       });
     } catch (_) {
       setState(() {
-        _aspects = [];
+        _options = [];
       });
     } finally {
       setState(() {
@@ -68,27 +68,27 @@ class _CotizadorSaludPageState extends State<CotizadorSaludPage> {
                         Expanded(
                           child: ReorderableListView.builder(
                             buildDefaultDragHandles: false,
-                            itemCount: _aspects.length,
+                            itemCount: _options.length,
                             onReorder: (oldIndex, newIndex) {
                               setState(() {
                                 if (newIndex > oldIndex) {
                                   newIndex -= 1;
                                 }
-                                final item = _aspects.removeAt(oldIndex);
-                                _aspects.insert(newIndex, item);
+                                final item = _options.removeAt(oldIndex);
+                                _options.insert(newIndex, item);
                               });
                             },
                             itemBuilder: (context, index) {
-                              final aspect = _aspects[index];
+                              final aspect = _options[index];
                               return ReorderableDragStartListener(
-                                key: ValueKey(aspect),
+                                key: ValueKey(aspect.id),
                                 index: index,
                                 child: Card(
                                   child: ListTile(
                                     leading: CircleAvatar(
                                       child: Text('${index + 1}'),
                                     ),
-                                    title: Text(aspect),
+                                    title: Text(aspect.descripcion),
                                     trailing:
                                         const Icon(Icons.open_with_outlined),
                                   ),
@@ -99,7 +99,7 @@ class _CotizadorSaludPageState extends State<CotizadorSaludPage> {
                         ),
                         const SizedBox(height: 20),
                         ElevatedButton(
-                          onPressed: _aspects.isEmpty
+                          onPressed: _options.isEmpty
                               ? null
                               : () {
                                   Navigator.push(
@@ -108,7 +108,7 @@ class _CotizadorSaludPageState extends State<CotizadorSaludPage> {
                                       builder: (_) =>
                                           FormularioCotizadorSaludPage(
                                         orderedAspects:
-                                            List<String>.from(_aspects),
+                                            List<PreferenceOption>.from(_options),
                                       ),
                                     ),
                                   );

--- a/lib/services/cotizar_salud_service.dart
+++ b/lib/services/cotizar_salud_service.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+import 'auth_service.dart';
+import '../models/preference_option.dart';
+import '../models/salud_quote.dart';
+
+class CotizarSaludService {
+  Future<List<SaludQuote>> cotizar({
+    required List<PreferenceOption> preferencias,
+    required int edad,
+    required String genero,
+  }) async {
+    final baseUrl = dotenv.env['API_BASE_URL'] ?? 'http://127.0.0.1:8000';
+    final url = Uri.parse('$baseUrl/api/cotizar_salud_por_preferencias');
+    final token = await AuthService().getToken();
+    final headers = {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      if (token != null) 'Authorization': 'Bearer $token',
+    };
+
+    final body = json.encode({
+      'preferencias': [
+        for (var i = 0; i < preferencias.length; i++)
+          {
+            'id': preferencias[i].id,
+            'orden': '${i + 1}',
+          },
+      ],
+      'parametros': {
+        'edad': '$edad',
+        'genero': genero,
+      },
+    });
+
+    final response = await http.post(url, headers: headers, body: body);
+
+    if (response.statusCode == 200) {
+      final List<dynamic> data = json.decode(response.body);
+      return data.map((e) => SaludQuote.fromJson(e)).toList();
+    }
+    throw Exception('Error al cotizar salud');
+  }
+}


### PR DESCRIPTION
## Summary
- add model for health quote response
- integrate API call to fetch quotes by preferences
- update preference ordering to keep IDs
- fetch and display quotes with rating stars

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c9568feb4832f9616fab298051915